### PR TITLE
FT-1345 Support aliases

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,23 @@ default this option will use the `revision` argument passed in from the command
 line, accessible by the `commandOptions.revision` property from the deployment
 context.
 
-*Default:* `context.commandOptions.revision'`
+*Default:* `this.readConfig('revisionKey')` if `--activate` passed to command. Otherwise `context.commandOptions.revision`
+
+### aliases
+
+A list of aliases that you'd like this revision to be linked to. This allows
+lightning servers to look up revisions based on other alises. You might want to
+do this if you'd like to refer to a revision by a git branch or ticket number
+which would be a rolling alias to a specific revision at any one point in time.
+Setting this property will make the following keys available:
+
+- `<namespace>/revisions/<revision-key>/aliases #=> 'foo,bar'`
+- `<namespace>/aliases/foo #=> '<revision-key>'`
+- `<namespace>/aliases/bar #=> '<revision-key>'`
+
+This way you can look up a list of aliases for a revision key, and also look up a revision key for an alias.
+
+*Default:* `[this.readConfig('revisionKey')]`
 
 ### recentRevisionsToken
 

--- a/index.js
+++ b/index.js
@@ -35,6 +35,10 @@ module.exports = {
         recentRevisionsToken: 'recent-revisions',
         activeRevisionToken: 'active-revision',
         revisionKeyToActivate: function(context) {
+          if (context.commandOptions && context.commandOptions.activate) {
+            return this.readConfig('revisionKey');
+          }
+
           return (context.commandOptions && context.commandOptions.revision);
         },
         metadata: function(context) {

--- a/index.js
+++ b/index.js
@@ -166,28 +166,52 @@ module.exports = {
           .then(function(revisionKeys) {
             if (revisionKeys.indexOf(revisionKey) === -1) {
               revisionKeys.unshift(revisionKey);
-
             }
 
-            return consul.setRecentRevisions(revisionKeys.join(','));
+            return consul.setRecentRevisions(revisionKeys);
           });
       },
 
       _trimRecentRevisions: function(consul, maxRevisions) {
+        var self = this;
+
         return consul.recentRevisionKeys()
           .then(function(revisionKeys) {
             if (!revisionKeys.length || revisionKeys.length <= maxRevisions) {
               return Promise.resolve();
             }
 
-            var remaining = revisionKeys.splice(0, maxRevisions);
+            return consul.getActiveRevision()
+              .then(self._determineKeysToRemove.bind(self, maxRevisions, revisionKeys))
+              .then(self._cleanUpKeys.bind(self, consul));
+          });
+      },
 
-            return consul.setRecentRevisions(remaining.join(','))
-              .then(function() {
-                  return Promise.all(revisionKeys.map(function(revisionKey) {
-                    return consul.deleteRevision(revisionKey);
-                  }, []));
-              });
+      _determineKeysToRemove: function(maxRevisions, revisionKeys, activeRevision) {
+        var numberToRemove = revisionKeys.length - maxRevisions;
+
+        var obj = revisionKeys.reverse().reduce(function(obj, key) {
+          if ((obj.toRemove.length === numberToRemove) || key === activeRevision) {
+            obj.toKeep.push(key);
+          } else {
+            obj.toRemove.push(key);
+          }
+
+          return obj;
+        }, { toRemove: [], toKeep: [] });
+
+        return Promise.resolve(obj);
+      },
+
+      _cleanUpKeys: function(consul, obj) {
+        var toKeep   = obj.toKeep.reverse();
+        var toRemove = obj.toRemove;
+
+        return consul.setRecentRevisions(toKeep)
+          .then(function() {
+              return Promise.all(toRemove.map(function(revisionKey) {
+                return consul.deleteRevision(revisionKey);
+              }, []));
           });
       },
 

--- a/lib/consul.js
+++ b/lib/consul.js
@@ -43,7 +43,7 @@ module.exports = CoreObject.extend({
   setRecentRevisions: function(value) {
     var key = this._namespaceToken + '/' + this._recentRevisionsToken;
 
-    return this._client.set(key, value);
+    return this._client.set(key, value.join(','));
   },
 
   deleteRevision: function(revisionKey) {

--- a/lib/consul.js
+++ b/lib/consul.js
@@ -54,7 +54,18 @@ module.exports = CoreObject.extend({
 
   deleteRevision: function(revisionKey) {
     var key = this._namespaceToken + '/revisions/' + revisionKey;
-    return this._client.del({ key: key, recurse: true });
+
+    return this._getLinkedAliasesForRevision(revisionKey)
+      .then(function(aliases) {
+        var promises = aliases.map(function(alias) {
+          return this._deleteAliasValue(alias);
+        }.bind(this));
+
+        return Promise.all(promises);
+      }.bind(this))
+      .then(function() {
+        return this._client.del({ key: key, recurse: true });
+      }.bind(this));
   },
 
   setActiveRevision: function(revisionKey) {
@@ -85,6 +96,12 @@ module.exports = CoreObject.extend({
     var key = this._namespaceToken + '/aliases/' + alias;
 
     return this._client.set(key, value);
+  },
+
+  _deleteAliasValue: function(alias) {
+    var key = this._namespaceToken + '/aliases/' + alias;
+
+    return this._client.del({ key: key, recurse: true });
   },
 
   _unlinkAliasFromRevision: function(alias, revisionKey) {

--- a/lib/consul.js
+++ b/lib/consul.js
@@ -25,6 +25,12 @@ module.exports = CoreObject.extend({
     return this._client.set(key, value);
   },
 
+  updateAlias: function(revisionKey, alias) {
+    return this._getAliasValue(alias)
+      .then(this._unlinkAliasFromRevision.bind(this, alias))
+      .then(this._updateAlias.bind(this, revisionKey, alias));
+  },
+
   setRevisionMetadata: function(revisionKey, value) {
     var key = this._namespaceToken + '/revisions/' + revisionKey + '/metadata';
 
@@ -67,6 +73,72 @@ module.exports = CoreObject.extend({
     var key = this._namespaceToken + '/' + this._recentRevisionsToken;
 
     return this._get(key);
+  },
+
+  _getAliasValue: function(alias) {
+    var key = this._namespaceToken + '/aliases/' + alias;
+
+    return this._get(key);
+  },
+
+  _setAliasValue: function(alias, value) {
+    var key = this._namespaceToken + '/aliases/' + alias;
+
+    return this._client.set(key, value);
+  },
+
+  _unlinkAliasFromRevision: function(alias, revisionKey) {
+    if (!revisionKey) {
+      return Promise.resolve();
+    }
+
+    return this._getLinkedAliasesForRevision(revisionKey)
+      .then(function(aliases) {
+        var index = aliases.indexOf(alias);
+
+        if (index > -1) {
+          aliases.splice(index, 1);
+        }
+
+        return Promise.resolve(aliases);
+      })
+      .then(this._setLinkedAliasesForRevision.bind(this, revisionKey));
+  },
+
+  _getLinkedAliasesForRevision: function(revisionKey) {
+    var key = this._namespaceToken + '/revisions/' + revisionKey + '/aliases';
+
+    return this._get(key)
+      .then(function(result) {
+        var value = (result && result.split(',')) || [];
+
+        return Promise.resolve(value);
+      });
+  },
+
+  _setLinkedAliasesForRevision: function(revisionKey, aliases) {
+    var key = this._namespaceToken + '/revisions/' + revisionKey + '/aliases';
+    aliases = aliases || [];
+
+    if (!aliases.length) {
+      return this._client.del({ key: key, recurse: true });
+    }
+
+    return this._client.set(key, aliases.join(','));
+  },
+
+  _updateAlias: function(revisionKey, alias) {
+    return this._getLinkedAliasesForRevision(revisionKey)
+      .then(function(aliases) {
+        if (aliases.indexOf(alias) === -1) {
+          aliases.push(alias);
+        }
+
+        return Promise.all([
+          this._setLinkedAliasesForRevision(revisionKey, aliases),
+          this._setAliasValue(alias, revisionKey)
+        ]);
+      }.bind(this));
   },
 
   _get: function(key) {

--- a/tests/helpers/mock-consul-client.js
+++ b/tests/helpers/mock-consul-client.js
@@ -28,6 +28,7 @@ var consulClient = {
   del: function(options) {
     delete this.store[options.key];
     delete this.store[options.key + '/metadata'];
+    delete this.store[options.key + '/aliases'];
     return Promise.resolve();
   }
 };

--- a/tests/unit/upload-nodetest.js
+++ b/tests/unit/upload-nodetest.js
@@ -253,12 +253,24 @@ describe('Consul KV Index | upload hook', function() {
         };
 
         consulClient.store['foo/recent-revisions'] = 'aaa,bbb,ccc';
+
+        consulClient.store['foo/aliases/aaa'] = 'aaa';
+        consulClient.store['foo/aliases/xxx'] = 'aaa';
         consulClient.store['foo/revisions/aaa'] = '111';
         consulClient.store['foo/revisions/aaa/metadata'] = '{"foo": 111}';
+        consulClient.store['foo/revisions/aaa/aliases'] = 'aaa,xxx';
+
+        consulClient.store['foo/aliases/bbb'] = 'bbb';
+        consulClient.store['foo/aliases/yyy'] = 'bbb';
         consulClient.store['foo/revisions/bbb'] = '222';
         consulClient.store['foo/revisions/bbb/metadata'] = '{"foo": 222}';
+        consulClient.store['foo/revisions/bbb/aliases'] = 'bbb,yyy';
+
+        consulClient.store['foo/aliases/ccc'] = 'ccc';
+        consulClient.store['foo/aliases/zzz'] = 'ccc';
         consulClient.store['foo/revisions/ccc'] = '333';
         consulClient.store['foo/revisions/ccc/metadata'] = '{"foo": 333}';
+        consulClient.store['foo/revisions/ccc/aliases'] = 'ccc,zzz';
 
         instance.beforeHook(context);
         instance.configure(context);
@@ -270,6 +282,9 @@ describe('Consul KV Index | upload hook', function() {
             assert.equal(consulClient.store[key], '1234,aaa,bbb');
             assert.isUndefined(consulClient.store['foo/revisions/ccc']);
             assert.isUndefined(consulClient.store['foo/revisions/ccc/metadata']);
+            assert.isUndefined(consulClient.store['foo/revisions/ccc/aliases']);
+            assert.isUndefined(consulClient.store['foo/aliases/ccc']);
+            assert.isUndefined(consulClient.store['foo/aliases/zzz']);
           });
       });
 


### PR DESCRIPTION
This PR adds the ability to assign aliases to deployed revisions. So, for the following config:

```javascript
ENV['consul-kv-index']: {
  revisionKey: 'foo',
  aliases: ['foo', 'bar']
}
```

The following additional keys will be stored:

- `<namespace>/revisions/foo/aliases` #=> 'foo,bar'
- `<namespace>/aliases/foo` #=> 'foo'
- `<namespace>/aliases/bar` #=> 'foo'

This allows a lightning server to look up a revision by it's alias to find out what the actual revision is.