### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ To get up and running quickly, do the following:
 - Install this plugin
 
 ```bash
-$ ember install ember-cli-deploy-consul-kv
+$ ember install ember-cli-deploy-consul-kv-index
 ```
 
 - Place the following configuration into `config/deploy.js`


### PR DESCRIPTION
There's a typo on the Ember install command, this fixes that :)